### PR TITLE
Introduce single detection mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ COPY entrypoint.sh /
 
 EXPOSE 80
 
-ENTRYPOINT /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,7 +20,10 @@ sh -c echo CS_testcontainer starting
 
 cd /home/eval/
 
-if [ -t 0 ] ; then
+if [ $# -ne 0 ]; then
+    # Arguments supplied, run the command specified in the arguments
+    bash -xc "$@"
+elif [ -t 0 ] ; then
     # Enter menu mode
     echo "(starting interactive shell)"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,17 +18,16 @@ sh -c echo CS_testcontainer starting
 #  Start webservices
 /usr/sbin/httpd -k start
 
-# Enter menu mode
+cd /home/eval/
+
 if [ -t 0 ] ; then
+    # Enter menu mode
     echo "(starting interactive shell)"
-    # Correct working directory
-    cd /home/eval/
 
     # Start menu
     ../menu/run
 else
     echo "(starting non-interactive shell)"
-    cd /home/eval
 
     # Start automatic run
     ../menu/auto


### PR DESCRIPTION
That is useful for showcasing particular detections on kubernetes environments.

Example usage:

    docker run -it --rm detection-container bin/Webserver_Bash_Reverse_Shell.sh