### PR TITLE
fix /run/php-fpm already exists

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,7 +16,7 @@ cp /bin/cat /bin/mysqldump
 sh -c echo CS_testcontainer starting
 
 #  Start webservices
-mkdir /run/php-fpm
+mkdir -p /run/php-fpm
 /usr/sbin/php-fpm
 /usr/sbin/httpd -k start
 


### PR DESCRIPTION
Container won't run and logs error on M2 Macbook Pro:
`2023-06-06 17:15:08 mkdir: cannot create directory '/run/php-fpm': File exists`

Added `-p` option to the command `mkdir /run/php-fpm` in `entrypoint.sh`, to not fail if folder exists.

After adding this option the container does run.