### PR TITLE
Fix typo in README.md, kubectl command references wrong filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,5 +105,5 @@ sudo docker run --rm quay.io/crowdstrike/detection-container
 For Kubernetes environments, use the following command to run the detection container non-interactively:
 
 ```bash
-kubectl create -f https://raw.githubusercontent.com/CrowdStrike/detection-container/main/detections.example.com
+kubectl create -f https://raw.githubusercontent.com/CrowdStrike/detection-container/main/detections.example.yaml
 ```


### PR DESCRIPTION
In the instructions for running the detection container non-interactively in Kubernetes environments, the kubectl command references the wrong file: it should be `detections.example.yaml` instead of `detections.example.com`